### PR TITLE
Migrating configurable options to Config.py class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /my_env
+__pycache__

--- a/app.py
+++ b/app.py
@@ -7,37 +7,50 @@ from flask_socketio import SocketIO, emit
 import time, random
 from datetime import datetime
 
+# Create an instance of flask called "app" and setup socketio
+app = Flask(__name__, static_url_path='/static')
+# load Production or Development config as appropriate
+# app.config.from_object('config.ProductionConfig')
+app.config.from_object('config.DevelopmentConfig')
+socketio = SocketIO(app)
+
+# Setup apscheduler job pool
+executors = {'default': ThreadPoolExecutor(16), 'processpool': ProcessPoolExecutor(4)}
+sched = BackgroundScheduler(timezone=app.config["TIME_ZONE"], executors=executors)
+
+###
+# Conditionally enable modules based on config.
+# News and Weather are on by default
 
 # Socket (not SocketIO) is used to receive TCP data from the PicoW
 # Set enablePicoData to False if you wish to disable this featue
-enablePicoData = False
+enablePicoData = app.config["ENABLE_PICO_DATA"]
 if enablePicoData:
     import socket
 
 # Feedparser is required for the bbc headline feed.
-# Set enableNews to False to disable the feature
-enableNews = True
+enableNews = app.config["ENABLE_NEWS"]
 if enableNews:
     import feedparser
 
 # Requests (not to be confused with flask request) is required for the weather feature.
-# Set enableWeather to False to disable the feature
-enableWeather = True
+enableWeather = app.config["ENABLE_WEATHER"]
 if enableWeather:
     import requests
     weather_message = "Historical weather data not available."
 
 # Sense hat is for the sensor data normally on the pi running the server.
-# Set enableSense to False to disable the featue
-enableSense = False
-if enableSense:
+# Set ENABLE_SENSE_HAT to False to disable the featue
+enableSenseHat = app.config["ENABLE_SENSE_HAT"]
+if enableSenseHat:
     from sense_hat import SenseHat
     sense = SenseHat()
 
 # Mote is for the Pimoroni Mote stick LEDs.
-# Set enableLights to False or replace this code and the code in the lights fuction with your own LED system
-enableLights = False
-if enableLights:
+# Set enableMotes to False or replace this code and the code in the 
+# lights function with your own LED system
+enableMotes = app.config["ENABLE_MOTES"]
+if enableMotes:
     try:
         from mote import Mote
         mote = Mote()
@@ -47,32 +60,24 @@ if enableLights:
         mote.configure_channel(4, 16, False)
     except OSError as e:
         print("Mote lights disabled due to an exception: ", e)
-        enableLights = False
+        enableMotes = False
 
 # PiMeteo is like an alternative to sensehat and will send the weather sensor data of the pimeteo you link
-# Set enablePimeteo to True if you have a PiMeteo setup up and running and also running the code you can find in the pimeteo-code/ folder
-enablePimeteo = False
+# Set ENABLE_PIMETEO to True if you have a PiMeteo setup up and running and also running the code you can find in the pimeteo-code/ folder
+enablePimeteo = app.config["ENABLE_PIMETEO"]
 if enablePimeteo and not(enablePicoData):
     import socket
 
-# Create an instance of flask called "app" and setup socketio
-app = Flask(__name__, static_url_path='/static')
-app.config['SECRET_KEY'] = 'secret!'
-socketio = SocketIO(app)
-
-# Setup apscheduler job pool
-executors = {'default': ThreadPoolExecutor(16), 'processpool': ProcessPoolExecutor(4)}
-sched = BackgroundScheduler(timezone='Asia/Seoul', executors=executors)
-
-# Set ritos defaults for server this could save and load json from a file later
-shipName = "USS Cerritos"
-shipClass = "California"
-shipRegistry = "NCC-75567"
-colorSchemeName = "Ritos Yellow"
+###
+# Configure UI appearance
+shipName        = app.config["SHIP_NAME"]
+shipClass       = app.config['SHIP_CLASS']
+shipRegistry    = app.config['SHIP_REGISTRY']
+colorSchemeName = app.config['COLOR_SCHEME']
 
 # Below is the list of possible color schemes available in the Ritos LCARS.
 # For a little fun set enableRandomColorScheme to true if you want to set the theme randomly when the server boots
-enableRandomColorScheme = False
+enableRandomColorScheme = app.config['RANDOM_COLOR_SCHEME']
 if enableRandomColorScheme:
     possibleColorScheme = ["Ritos Yellow", "Sickbay Aqua", "Picard Gray", "Nemesis Cyan", "Padd Blue", "Titan PurpleHead", "Vancouver Orange", "Merced Green", "Oakland Glory", "Inglewood Violet", "Carlsbad Nature", "Prodigy Blast", "Ketracel White", "Disco Beige", "Shipyard Blueprint", "Shipyard Blueprint II", "Red Alert"]
     colorSchemeName = random.choice(possibleColorScheme)
@@ -81,11 +86,11 @@ if enableRandomColorScheme:
 serverstatus = {"alertStatus":"normal", "colorSchemeName":colorSchemeName, "shipName":shipName, "shipClass":shipClass, "shipRegistry":shipRegistry, "themeColor":"rgb(255, 211, 0)", "themeColorR":255, "themeColorG":211, "themeColorB":0}
 
 # Pulling Sensor data from sensehat
-if enableSense:
+if enableSenseHat:
     sensordata = {"Temperature":round(sense.temp, 2) , "Humidity":round(sense.humidity, 2) , "Pressure":round(sense.pressure, 2)}
 
 # Just to set the variable if it is not set yet
-if enablePimeteo and not(enableSense):
+if enablePimeteo and not(enableSenseHat):
     sensordata = {"Temperature":round(0, 2) , "Humidity":round(0, 2) , "Pressure":round(0, 2)}
 
 # Had issues with JSON from clients JS so this function cleans up the JSON for Python
@@ -108,7 +113,7 @@ def fetchStatus(data):
     remoteLogMsg = {"message":msg, "showTimePrefix":True}
     print(msg)
     socketio.emit('remoteLogMsg', remoteLogMsg)
-    if enableSense or enablePimeteo:
+    if enableSenseHat or enablePimeteo:
         socketio.emit('updateSensorData', sensordata)
     if enableWeather:
         sendmessage(weather_message, True, True)
@@ -137,7 +142,7 @@ def process():
 
 # Function for the lights - Using Pimoroni mote sticks
 def lights():
-    if enableLights:
+    if enableMotes:
         global redalertstatus
         rgb = (0, 0, 0)
         r, g, b = rgb
@@ -184,7 +189,7 @@ def getpicowudp():
 
 # If enabled you can get the last bbc headline sent to the all connected clients
 def getbbcheadline():
-    feed_url = "http://feeds.bbci.co.uk/news/rss.xml"
+    feed_url = app.config["NEWS_FEED_URL"]
     feed = feedparser.parse(feed_url)
     entry = feed.entries[0]
     msg = "Viewing historical news data: " + entry.title
@@ -271,7 +276,7 @@ def getpimeteostats():
 
 # Adding functions as a scheduled jobs because its a while loop running forever it should run in its own thread
 sched.add_job(lights)
-if enableSense:
+if enableSenseHat:
     print("SenseHat enabled")
     sched.add_job(getsensordata, 'interval', minutes=2)
 if enableNews:
@@ -297,4 +302,4 @@ if __name__ == "__main__":
     # Start all jobs
     sched.start()
     # Run server on host pi's IP and hostname so it can be accessed on the local network
-    socketio.run(app, host='0.0.0.0', port=5000)
+    socketio.run(app, host=app.config['APP_IP'], port=app.config['APP_PORT'], debug=app.config['DEBUG'])

--- a/config.py
+++ b/config.py
@@ -1,0 +1,62 @@
+import os
+basedir = os.path.abspath(os.path.dirname(__file__))
+
+
+class Config:
+    ## Flask Configs
+    SECRET_KEY          = "U55P1r1t0s!"
+    # IP to bind to. Either 0.0.0.0 to be accessible to the network or
+    # or 127.0.0.1 to limit access to localhost
+    APP_IP              = "0.0.0.0" 
+    APP_PORT            = 5000
+
+    ## Pi RITOS Appearance
+    SHIP_NAME           = "USS Cerritos"
+    SHIP_CLASS          = "California"
+    SHIP_REGISTRY       = "NCC-75567"
+    COLOR_SCHEME        = "Ritos Yellow"
+    RANDOM_COLOR_SCHEME = False
+    TIME_ZONE           = "America/Los_Angeles"
+
+    ## Pi RIOTS add-ons
+    # News
+    ENABLE_NEWS         = True
+    NEWS_FEED_URL       = "http://feeds.bbc.co.uk/news/rss.xml"
+
+    # Weather
+    ENABLE_WEATHER      = True
+    WEATHER_LAT         = "37.82"    # Default location is Starfleet Academy
+    WEATHER_LONG        = "-122.48"  # current day Fork Baker, CA
+
+    # PICO W temp collection (see picow-code dir)
+    ENABLE_PICO_DATA    = False
+
+    # Sense Hat
+    ENABLE_SENSE_HAT    = False
+
+    # Enable Pimoroni Mote Sticks (LED)
+    ENABLE_MOTES        = False
+
+    # PiMeteo temp collection (see pimeteo-code dir)
+    ENABLE_PIMETEO      = False
+
+
+
+    @staticmethod
+    def init_app(app):
+        pass
+
+
+class DevelopmentConfig(Config):
+    DEBUG               = True
+    APP_IP              = "127.0.0.1" 
+    APP_PORT            = 5001
+    SHIP_NAME            = "USS Devritos"
+    SHIP_CLASS           = "Oberth"
+    SHIP_REGISTRY        = "NCC-68443"
+    COLOR_SCHEME         = "Inglewood Violet"
+
+
+class ProductionConfig(Config):
+    DEBUG = False
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ Flask-APScheduler==1.13.1
 Flask-SocketIO==5.3.7
 gevent-websocket==0.10.1
 requests==2.32.3
+sense-hat==2.6.0
+mote==0.0.4


### PR DESCRIPTION
* Refactor all config options into config.py
* Renamed a couple of config vars in the refactor
  * enableSense -> enableSenseHat
  * enableLights -> enableMotes
* Move flask, socketio, executors, and sched instantiaion to top
* Add some comments to mark out sections
* Add sense-hat and mote to requirments.txt
* update .gitignore